### PR TITLE
use a single toArray function instead of importing the whole lodash library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-editor-core",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "editor-core ui component for react",
   "keywords": [
     "react",

--- a/src/EditorCore/customHTML2Content.ts
+++ b/src/EditorCore/customHTML2Content.ts
@@ -1,5 +1,5 @@
 import { BlockMapBuilder, BlockMap, ContentState, genKey, Entity, CharacterMetadata, ContentBlock, convertFromHTML } from 'draft-js'
-import { toArray } from 'lodash';
+import toArray from 'lodash/toArray';
 import DraftEntityInstance = Entity.DraftEntityInstance;
 import CharacterMetadataConfig = CharacterMetadata.CharacterMetadataConfig;
 import { List, OrderedSet, Repeat, fromJS } from 'immutable'


### PR DESCRIPTION
It can reduce the bundle size significantly