### PR TITLE
Fixes cursor jumping of draftJs by changing the focus event

### DIFF
--- a/src/EditorCore/index.tsx
+++ b/src/EditorCore/index.tsx
@@ -348,7 +348,7 @@ class EditorCore extends React.Component<EditorProps, EditorCoreState> {
       if (!selection.getHasFocus()) {
         if (selection.isCollapsed()) {
           return this.setState({
-            editorState: EditorState.moveFocusToEnd(editorState),
+            editorState: EditorState.moveSelectionToEnd(editorState),
           }, () => {
             this.focusEditor(ev);
           });


### PR DESCRIPTION
I had the same issues similar to ones mentioned in:
here: https://github.com/facebook/draft-js/issues/1198
and here: https://github.com/facebook/draft-js/issues/410

I was able to fix the issue of cursor jumping (which was occurring on focus) by changing the focus event