### PR TITLE
Remove unclear warning

### DIFF
--- a/src/EditorCore/index.tsx
+++ b/src/EditorCore/index.tsx
@@ -154,7 +154,6 @@ class EditorCore extends React.Component<EditorProps, EditorCoreState> {
 
     if (props.value !== undefined) {
       this.controlledMode = true;
-      console.warn('this component is in controllred mode');
     }
   }
 


### PR DESCRIPTION
This warning contains a typo and doesn't actually reflect something that should be warned about, controlling the value is useful and the functionality for doing so is implemented.