### PR TITLE
Lists react/react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "setimmediate": "^1.0.5"
   },
   "peerDependencies": {
-    "react": ">=15.x",
-    "react-dom": ">=15.x"
+    "react": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0"
   },
   "pre-commit": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "setimmediate": "^1.0.5"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0",
+    "react": ">=15",
     "react-dom": ">=15"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0"
+    "react-dom": ">=15"
   },
   "pre-commit": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
     "prop-types": "^15.5.8",
     "setimmediate": "^1.0.5"
   },
+  "peerDependencies": {
+    "react": ">=15.x",
+    "react-dom": ">=15.x"
+  },
   "pre-commit": [
     "lint"
   ]

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "setimmediate": "^1.0.5"
   },
   "peerDependencies": {
-    "react": ">=15",
-    "react-dom": ">=15"
+    "react": ">=15.0.0",
+    "react-dom": ">=15.0.0"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
The `draft-js` package has peer dependencies on `react` and `react-dom`, which means that `editor-core` also depends on them.

Related: https://github.com/react-component/editor-mention/pull/35
Related: https://github.com/react-component/tabs/pull/169